### PR TITLE
Support nonce attribute for lasso

### DIFF
--- a/font/marketsans/template.marko
+++ b/font/marketsans/template.marko
@@ -1,9 +1,9 @@
-<style>
+<style lasso-nonce>
     .font-marketsans > body {
         font-family: "Market Sans","Helvetica Neue", Helvetica,Arial,Roboto,sans-serif
     }
 </style>
-<script>
+<script lasso-nonce>
     var useCustomFont = ('fontDisplay' in document.documentElement.style) ||
                     (localStorage && localStorage.getItem('ebay-font'));
     if (useCustomFont) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",
-    "karma-lasso": "^3.0.1",
+    "karma-lasso": ">=3.0.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.3",
     "lasso": ">=2.0.0",


### PR DESCRIPTION
Support nonce attribute for Content Security Policy using `lasso-nonce` (see https://github.com/lasso-js/lasso#content-security-policy-support). 

This is a simple implementation to support issue https://github.com/eBay/ebay-font/issues/28, if lasso has its `cspNonceProvider` configured properly, it will inject nonce value automatically.