### PR TITLE
Nonce attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,18 @@ npm install ebay-font --save
 ```html
 <html>
 <head>
-    <ebay-font>
+    <ebay-font/>
     ... 
 </head>
 ...
 </html>
+```
+
+* Note: If your website uses Content Security Policy (CSP), you can pass the CSP nonce value to `<ebay-font>` tag
+```html
+...
+    <ebay-font nonce="4AEemGb0xJptoIGFP3Nd"/>
+...
 ```
 
 ### Standalone

--- a/font/marketsans/template.marko
+++ b/font/marketsans/template.marko
@@ -1,9 +1,9 @@
-<style>
+<style nonce=input.nonce>
     .font-marketsans > body {
         font-family: "Market Sans","Helvetica Neue", Helvetica,Arial,Roboto,sans-serif
     }
 </style>
-<script>
+<script nonce=input.nonce>
     var useCustomFont = ('fontDisplay' in document.documentElement.style) ||
                     (localStorage && localStorage.getItem('ebay-font'));
     if (useCustomFont) {

--- a/test/unit-test/index.js
+++ b/test/unit-test/index.js
@@ -10,10 +10,28 @@ describe('ebay-font ', function() {
             if (err) {
                 done(err);
             }
-            expect(output).not.to.be.empty; // eslint-disable-line no-unused-expressions
+            var htmlStr = output.toString();
+            expect(htmlStr).to.contain('<style>')
+                .and.to.contain('<script>');
+
             done();
         };
         out.global = {};
         renderer({}, out);
+    });
+
+    it('should render attribute nonce', function(done) {
+        var out = function(err, output) {
+            if (err) {
+                done(err);
+            }
+            var htmlStr = output.toString();
+            expect(htmlStr).to.contain('<style nonce="test-123">')
+                .and.to.contain('<script nonce="test-123">');
+
+            done();
+        };
+        out.global = {};
+        renderer({ nonce: 'test-123' }, out);
     });
 });


### PR DESCRIPTION
Another option in order to support CSP since the [lasso-nonce solution](https://github.com/eBay/ebay-font/pull/29) did not work.

- Add optional attribute `nonce` to ebay-font Marko component.
- Add unit tests
- Update README accordingly