### PR TITLE
Fix Chrome headless problem on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-sudo: false
+# Work-around for https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524.
+sudo: required
 
 node_js:
   - 8

--- a/README.md
+++ b/README.md
@@ -21,11 +21,18 @@ npm install ebay-font --save
 ```html
 <html>
 <head>
-    <ebay-font>
+    <ebay-font/>
     ... 
 </head>
 ...
 </html>
+```
+
+* Note: If your website uses Content Security Policy (CSP), you can pass the CSP nonce value to `<ebay-font>` tag
+```html
+...
+    <ebay-font nonce="4AEemGb0xJptoIGFP3Nd"/>
+...
 ```
 
 ### Standalone

--- a/font/marketsans/template.marko
+++ b/font/marketsans/template.marko
@@ -1,9 +1,9 @@
-<style>
+<style nonce=input.nonce>
     .font-marketsans > body {
         font-family: "Market Sans","Helvetica Neue", Helvetica,Arial,Roboto,sans-serif
     }
 </style>
-<script>
+<script nonce=input.nonce>
     var useCustomFont = ('fontDisplay' in document.documentElement.style) ||
                     (localStorage && localStorage.getItem('ebay-font'));
     if (useCustomFont) {

--- a/test/unit-test/index.js
+++ b/test/unit-test/index.js
@@ -10,10 +10,28 @@ describe('ebay-font ', function() {
             if (err) {
                 done(err);
             }
-            expect(output).not.to.be.empty; // eslint-disable-line no-unused-expressions
+            var htmlStr = output.toString();
+            expect(htmlStr).to.contain('<style>')
+                .and.to.contain('<script>');
+
             done();
         };
         out.global = {};
         renderer({}, out);
+    });
+
+    it('should render attribute nonce', function(done) {
+        var out = function(err, output) {
+            if (err) {
+                done(err);
+            }
+            var htmlStr = output.toString();
+            expect(htmlStr).to.contain('<style nonce="test-123">')
+                .and.to.contain('<script nonce="test-123">');
+
+            done();
+        };
+        out.global = {};
+        renderer({ nonce: 'test-123' }, out);
     });
 });


### PR DESCRIPTION
There is problem Chrome headless (through puppeteer) failed to start on Travis. 
> Cannot start ChromeHeadless
0115/155529.224975:FATAL:zygote_host_impl_linux.cc(123)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.

This break the build on Travis which I noticed when I create this PR (https://github.com/eBay/ebay-font/pull/33). I also re-trigger the build on master on my fork, and the build failed as well (https://travis-ci.org/abiyasa/ebay-font/builds/330444622?utm_source=github_status&utm_medium=notification)

See:
 
- https://github.com/GoogleChrome/puppeteer/issues/290
- workaround: https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524

