### PR TITLE
Fix Chrome headless problem on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-sudo: false
+# Work-around for https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524.
+sudo: required
 
 node_js:
   - 8


### PR DESCRIPTION
There is problem Chrome headless (through puppeteer) failed to start on Travis. 
> Cannot start ChromeHeadless
0115/155529.224975:FATAL:zygote_host_impl_linux.cc(123)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.

This break the build on Travis which I noticed when I create this PR (https://github.com/eBay/ebay-font/pull/33). I also re-trigger the build on master on my fork, and the build failed as well (https://travis-ci.org/abiyasa/ebay-font/builds/330444622?utm_source=github_status&utm_medium=notification)

See:
 
- https://github.com/GoogleChrome/puppeteer/issues/290
- workaround: https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524

