### PR TITLE
moving skin to a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,8 @@
     "test": "npm run lint && npm run utest && npm run ftest",
     "all": "npm run clean && npm run test && npm run coverage"
   },
-  "dependencies": {
-    "@ebay/skin": ">=3.1.0"
-  },
   "devDependencies": {
+    "@ebay/skin": ">=3.1.0",
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "eslint": "^4.18.2",
@@ -52,6 +50,7 @@
     "uglify-js": "^3.1.1"
   },
   "peerDependencies": {
+    "@ebay/skin": ">=3.1.0",
     "lasso": ">=2.0.0",
     "marko": ">=3.0.0"
   }


### PR DESCRIPTION
With skin defined as a dependency, applications are bringing in multiple versions of skin.  As a peer dependency we will only bring in one consistent version.